### PR TITLE
Add missing include for std::transform

### DIFF
--- a/pe/pe_imports.cpp
+++ b/pe/pe_imports.cpp
@@ -1,4 +1,5 @@
 #include "pe_imports.h"
+#include <algorithm>
 #include <filesystem>
 
 namespace fs = std::filesystem;


### PR DESCRIPTION
std::transform is provided by `<algorithm>`, should be included explicitly, otherwise compilation fails on gcc 14.2.1 with libstdc++.